### PR TITLE
Mudança no menu status

### DIFF
--- a/Clicker.js
+++ b/Clicker.js
@@ -456,7 +456,7 @@ function upgradeAutoClick(button, prices, level, compra) {
                     break;
                 case 'multiplier':
                     console.log(`O multiplicador do clique (auto click) aumentou: ${autoClick.multiplier / 100}X -> ${(autoClick.multiplier + 20) / 100}X.`);
-                    autoClick.multiplier += 10;
+                    autoClick.multiplier += 20;
                     autoClick.levels.multiplier++;
                     level = autoClick.levels.multiplier;
                     break;

--- a/Clicker.js
+++ b/Clicker.js
@@ -608,14 +608,17 @@ function updateStats() {
     document.querySelector("#money-total").textContent = moneyGanhoTotal;
     document.querySelector("#money-gasto").textContent = moneyGastoTotal;
     document.querySelector("#click-power-stats").textContent = manual.clickPower;
-    document.querySelector("#click-mult-stats").textContent = manual.multiplier;
-    document.querySelector("#click-delay-stats").textContent = manual.clickDelay;
+    document.querySelector("#click-mult-stats").textContent = `${manual.multiplier}%`;
+    document.querySelector("#click-delay-stats").textContent = `${manual.clickDelay / 1000}s`;
     document.querySelector("#click-power-level-stats").textContent = manual.levels.click;
     document.querySelector("#click-mult-level-stats").textContent = manual.levels.multiplier;
     document.querySelector("#click-delay-level-stats").textContent = manual.levels.clickDelay;
     document.querySelector("#auto-click-power-stats").textContent = autoClick.clickPower;
     document.querySelector("#auto-click-mult-stats").textContent = `${autoClick.multiplier}%`;
     document.querySelector("#auto-click-delay-stats").textContent = `${autoClick.clickDelay / 1000}s`;
+    document.querySelector("#auto-click-power-level-stats").textContent = autoClick.levels.clickPower;
+    document.querySelector("#auto-click-mult-level-stats").textContent = autoClick.levels.multiplier;
+    document.querySelector("#auto-click-delay-level-stats").textContent = autoClick.levels.clickDelay;
     document.querySelector("#click-multiplier-bonus-stats").textContent = `${bonusMultiplier}%`;
     document.querySelector("#delay-multiplier-stats").textContent = `${delayMultiplier}%`;
 }

--- a/Clicker.js
+++ b/Clicker.js
@@ -616,7 +616,7 @@ function updateStats() {
     document.querySelector("#auto-click-power-stats").textContent = autoClick.clickPower;
     document.querySelector("#auto-click-mult-stats").textContent = `${autoClick.multiplier}%`;
     document.querySelector("#auto-click-delay-stats").textContent = `${autoClick.clickDelay / 1000}s`;
-    document.querySelector("#auto-click-power-level-stats").textContent = autoClick.levels.clickPower;
+    document.querySelector("#auto-click-power-level-stats").textContent = autoClick.levels.click;
     document.querySelector("#auto-click-mult-level-stats").textContent = autoClick.levels.multiplier;
     document.querySelector("#auto-click-delay-level-stats").textContent = autoClick.levels.clickDelay;
     document.querySelector("#click-multiplier-bonus-stats").textContent = `${bonusMultiplier}%`;

--- a/Clicker.js
+++ b/Clicker.js
@@ -607,6 +607,12 @@ checkboxPocaoDelay.addEventListener('click', function () {
 function updateStats() {
     document.querySelector("#money-total").textContent = moneyGanhoTotal;
     document.querySelector("#money-gasto").textContent = moneyGastoTotal;
+    document.querySelector("#click-power-stats").textContent = manual.clickPower;
+    document.querySelector("#click-mult-stats").textContent = manual.multiplier;
+    document.querySelector("#click-delay-stats").textContent = manual.clickDelay;
+    document.querySelector("#click-power-level-stats").textContent = manual.levels.click;
+    document.querySelector("#click-mult-level-stats").textContent = manual.levels.multiplier;
+    document.querySelector("#click-delay-level-stats").textContent = manual.levels.clickDelay;
     document.querySelector("#auto-click-power-stats").textContent = autoClick.clickPower;
     document.querySelector("#auto-click-mult-stats").textContent = `${autoClick.multiplier}%`;
     document.querySelector("#auto-click-delay-stats").textContent = `${autoClick.clickDelay / 1000}s`;

--- a/Clicker.js
+++ b/Clicker.js
@@ -236,7 +236,7 @@ function createBuff(buffType, multiplierVariable, multiplier, counter, time) {
             buffsContainer.style.display = "none";
         }
     }, 1000);
-    console.log(`Foi comprado um buff de ${buffTtype} com um multiplicador de ${multiplier} que durará ${time} segundos.`);
+    console.log(`Foi comprado um buff de ${buffType} com um multiplicador de ${multiplier} que durará ${time} segundos.`);
 }
 function updateBuff(type, time) {
     switch (type) {

--- a/Clicker.js
+++ b/Clicker.js
@@ -606,10 +606,7 @@ checkboxPocaoDelay.addEventListener('click', function () {
 })
 function updateStats() {
     document.querySelector("#money-total").textContent = moneyGanhoTotal;
-    document.querySelector("#money-gasto").textContent = moneyGastoTotal
-    document.querySelector("#click-power-stats").textContent = manual.clickPower;
-    document.querySelector("#click-mult-stats").textContent = `${manual.multiplier}%`;
-    document.querySelector("#click-delay-stats").textContent = `${manual.clickDelay / 1000}s`;
+    document.querySelector("#money-gasto").textContent = moneyGastoTotal;
     document.querySelector("#auto-click-power-stats").textContent = autoClick.clickPower;
     document.querySelector("#auto-click-mult-stats").textContent = `${autoClick.multiplier}%`;
     document.querySelector("#auto-click-delay-stats").textContent = `${autoClick.clickDelay / 1000}s`;

--- a/index.html
+++ b/index.html
@@ -323,6 +323,9 @@
       border: 1px black solid;
       background-color: rgba(200, 200, 200, 0.5);
     }
+    #stats table td {
+      border: 1px black solid;
+    }
     @media (orientation: landscape) {
       #upgrades .content {
         display: flex;
@@ -572,15 +575,15 @@
         <tbody>
           <tr>
             <th>Valor</th>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td id="click-power-stats"></td>
+            <td id="click-mult-stats"></td>
+            <td id="click-delay-stats"></td>
           </tr>
           <tr>
             <th>Nível</th>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td id="click-power-level-stats"></td>
+            <td id="click-mult-level-stats"></td>
+            <td id="click-delay-level-stats"></td>
           </tr>
         </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -325,6 +325,7 @@
     }
     #stats table td {
       border: 1px black solid;
+      text-align: center;
     }
     @media (orientation: landscape) {
       #upgrades .content {

--- a/index.html
+++ b/index.html
@@ -313,6 +313,16 @@
       font-size: 18px;
     }
 
+    #stats table {
+      border-collapse: collapse;
+    }
+
+    #stats table th {
+      font-weight: bold;
+      color: black;
+      border: 1px black solid;
+      background-color: rgba(200, 200, 200, 0.5);
+    }
     @media (orientation: landscape) {
       #upgrades .content {
         display: flex;
@@ -550,9 +560,30 @@
       <span>Total de dinheiro acumulado: <span id="money-total">0</span></span><br>
       <span>Total de dinheiro gasto: <span id="money-gasto">0</span></span><br>
       <span>Total de cliques: <span id="clickes">0</span></span><br>
-      <span>Poder do clique (manual): <span id="click-power-stats"></span></span><br>
-      <span>Multiplicador do click (manual): <span id="click-mult-stats"></span></span><br>
-      <span>Delay do click (manual): <span id="click-delay-stats"></span></span><br>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Poder do click</th>
+            <th>Multiplicador do click</th>
+            <th>Delay do click</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Valor</th>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <th>Nível</th>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
       <span>Poder do clique (auto click): <span id="auto-click-power-stats"></span></span><br>
       <span>Multiplicador do click (auto click): <span id="auto-click-mult-stats"></span></span><br>
       <span>Delay do click (auto click): <span id="auto-click-delay-stats"></span></span><br>

--- a/index.html
+++ b/index.html
@@ -564,6 +564,9 @@
       <span>Total de dinheiro gasto: <span id="money-gasto">0</span></span><br>
       <span>Total de cliques: <span id="clickes">0</span></span><br>
       <table>
+        <caption>
+          click manual
+        </caption>
         <thead>
           <tr>
             <th></th>
@@ -587,9 +590,33 @@
           </tr>
         </tbody>
       </table>
-      <span>Poder do clique (auto click): <span id="auto-click-power-stats"></span></span><br>
-      <span>Multiplicador do click (auto click): <span id="auto-click-mult-stats"></span></span><br>
-      <span>Delay do click (auto click): <span id="auto-click-delay-stats"></span></span><br>
+      <table>
+        <caption>
+          auto click
+        </caption>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Poder do click</th>
+            <th>Multiplicador do click</th>
+            <th>Delay do click</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Valor</th>
+            <td id="auto-click-power-stats"></td>
+            <td id="auto-click-mult-stats"></td>
+            <td id="auto-click-delay-stats"></td>
+          </tr>
+          <tr>
+            <th>Nível</th>
+            <td id="auto-click-power-level-stats"></td>
+            <td id="auto-click-mult-level-stats"></td>
+            <td id="auto-click-delay-level-stats"></td>
+          </tr>
+        </tbody>
+      </table>
       <span>Multiplicador do click (bonus): <span id="click-multiplier-bonus-stats"></span></span><br>
       <span>Multiplicador do delay: <span id="delay-multiplier-stats"></span></span>
     </div>


### PR DESCRIPTION
### alterações:
- Substitui as informações sobre o auto clicker e o click manual por duas tabelas, cada uma com as informações anteriores de multiplicador, delay e click só que agora também mostrando os níveis.
- O incremento no multiplicador do auto clicker após cada compra aumentou de 10% -> 20%.

### bug fixes:
- corrigido erro no log que aparecia ao comprar um buff. Ocasionava de ao carregar as informações salvas, caso tivesse um buff ativo, o auto clicker e as poções permanentes não seriam carregados.